### PR TITLE
node-fibers script breaks again after node fixed streaming from stdin

### DIFF
--- a/bin/node-fibers
+++ b/bin/node-fibers
@@ -11,7 +11,8 @@ if [[ -e $(dirname "$0")/../src/fibers.node ]]; then
 	FIBERS_ROOT=$(dirname "$0")/../src
 else
 	# in npm
-	FIBERS_ROOT=$(dirname $(echo "console.log(require.resolve('fibers'));" | $NODE))/src
+	# node 4.x has a bug causing a broken pipe error here
+	FIBERS_ROOT=$(dirname $(echo "console.log(require.resolve('fibers'));" | $NODE | head -n1 | sed 's/> //'))/src
 	if [[ ! -e "$FIBERS_ROOT/fibers.node" ]]; then
 		echo "Could not find the coroutine shim!" 1>&2
 		exit 1
@@ -31,5 +32,5 @@ elif [[ "$UNAME" == "Darwin" ]]; then
 	$NODE "$@"
 else
 	echo "This OS is not supported."
-        exit 1
+	exit 1
 fi


### PR DESCRIPTION
Did it really extract a path from error message? : )
Here goes a version for fixed node. Doesn't support broken node though (not sure if it's worth adding a w/a since not too many node versions seem to be affected).
Also changed `` to $() since it's considered better style.
