### PR TITLE
Make the startup script call exec instead of forking a child.

### DIFF
--- a/bin/node-fibers
+++ b/bin/node-fibers
@@ -23,13 +23,13 @@ UNAME=$(uname)
 if [[ "$UNAME" == "Linux" ]]; then
 	FIBER_SHIM=1 \
 	LD_PRELOAD="$FIBERS_ROOT/coroutine.so" \
-	$NODE "$@"
+	exec $NODE "$@"
 elif [[ "$UNAME" == "Darwin" ]]; then
 	FIBER_SHIM=1 \
 	DYLD_INSERT_LIBRARIES="$FIBERS_ROOT/coroutine.dylib" \
 	DYLD_FORCE_FLAT_NAMESPACE=1 \
 	DYLD_LIBRARY_PATH="$FIBERS_ROOT" \
-	$NODE "$@"
+	exec $NODE "$@"
 else
 	echo "This OS is not supported."
 	exit 1


### PR DESCRIPTION
This change makes it easier to use node-fibers with node-supervisor,
or any other tool that monitors the health of the node process.  It
also results in a simpler process structure, and makes "node-fibers"
closer to a true drop-in replacement for "node".
