### PR TITLE
Use /bin/sh instead of /bin/bash to run the tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 for ii in `ls test`
 	do echo -n $ii': '
 	OUTPUT=$(NODE_PATH=`pwd` node test/$ii 2>&1)


### PR DESCRIPTION
There's no bash specific syntax, and some OSes don't ship with
bash (e.g. OpenBSD).
