### PR TITLE
Build correctly on OpenBSD

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,9 @@ endif
 ifeq ($(NODE_PLATFORM), darwin)
 	CPP_NODEFLAGS = -bundle -undefined dynamic_lookup
 endif
+ifeq ($(NODE_PLATFORM), openbsd)
+       CPP_NODEFLAGS = -fPIC -shared -Wl,-Bdynamic
+endif
 
 all: fibers.node
 

--- a/src/platform.mk
+++ b/src/platform.mk
@@ -39,3 +39,6 @@ ifeq ($(NODE_PLATFORM), darwin)
 	# UCONTEXT in os x = hangs & segfaults :(
 	CPPFLAGS += -DCORO_SJLJ
 endif
+ifeq ($(NODE_PLATFORM), openbsd)
+       CPPFLAGS += -DCORO_ASM
+endif


### PR DESCRIPTION
I tested this on OpenBSD-current on both amd64 and i386.  It's not
the only changes necessary to build though (you also have to use
gmake instead of make), but these shouldn't have a negative effect
on other OSes.
