### PR TITLE
Fix NODE_BITS determination using process.arch

### DIFF
--- a/src/platform.mk
+++ b/src/platform.mk
@@ -1,7 +1,7 @@
 # I know nothing about scons, waf, or autoconf. Sorry.
 NODE_PREFIX := $(shell node -e "console.log(require('path').dirname(require('path').dirname(process.execPath)))")
 NODE_PLATFORM := $(shell node -e "console.log(process.platform.replace('2', ''))")
-NODE_BITS := $(shell file `node -e "console.log(process.execPath)"` | egrep -o '[0-9]{2}-bit' | cut -c-2)
+NODE_BITS := $(shell file `echo "console.log(process.arch.replace(/ia|x/, ''))" | node`)
 
 CPPFLAGS = -Wall -Wno-deprecated-declarations -I$(NODE_PREFIX)/include -I$(NODE_PREFIX)/include/node
 ifdef DEBUG


### PR DESCRIPTION
process.arch is either ia32 or x64, so use that to determine
NODE_BITS.  The existing code is broken in that it will assume
32-bit on many 64-bit platforms (e.g. OpenBSD).
