### PR TITLE
Make Future.wrap deal with a fn.length of 0

### DIFF
--- a/future.js
+++ b/future.js
@@ -22,11 +22,15 @@ Future.wrap = function(fn, idx) {
 	idx = idx === undefined ? fn.length - 1 : idx;
 	return function() {
 		var args = Array.prototype.slice.call(arguments);
-		if (args.length > idx) {
+		if (idx >= 0 && args.length > idx) {
 			throw new Error('function expects no more than '+ idx+ ' arguments');
 		}
 		var future = new Future;
-		args[idx] = future.resolver();
+		if (idx >= 0) {
+		  args[idx] = future.resolver();
+		} else {
+		  args.push(future.resolver())
+		}
 		fn.apply(this, args);
 		return future;
 	};


### PR DESCRIPTION
I'm not sure if this is the correct way to handle things by
default, or even if there is a correct way to handle
things by default.  My use case here is with crypto.randomBytes.
In node, crypto.randomBytes.length returns 0, which causes idx to
be -1.  This fixes the wrapping of crypto.randomBytes, with no
side-effects in my code, but I'm not sure it is correct. It assumes
that the callback function is the last argument, and the user is
providing all arguments other than the callback.  That seems like
a reasonable default to me.
