### PR TITLE
cannot install via npm >= 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
 		"type": "git",
 		"url": "git://github.com/laverdet/node-fibers.git"
 	},
-	"os": ["macos", "linux"],
+	"os": ["darwin", "linux"],
 	"engines": {
-		"node": ">=0.5.2",
-        "npm": "<=1.1.5"
+		"node": ">=0.5.2"
 	}
 }


### PR DESCRIPTION
npm version 1.1.6 implements checking on the os property in the package.json file.  For osx, node reports "darwin", not "macos", so installing node-fibers will fail the os check.  There are two commits in this pull request.  The first adds a check for the npm version (installation with newer npm will still fail, with a better error message), and the second commit updates the os dependency to use "darwin" instead of "macos".

I didn't touch the node-fibers version number.

Thanks,
- JP
