### PR TITLE
FreeBSD and gmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ FIBERS_SO := $(shell echo `pwd`/src/fibers.node)
 all: fibers test
 
 native:
-	FIBERS_NATIVE=1 make all
+	FIBERS_NATIVE=1 ${MAKE} all
 
 fibers: $(FIBERS_SO)
 

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
 	"author": "Marcel Laverdet <marcel@laverdet.com> (https://github.com/laverdet/)",
 	"main": "fibers",
 	"scripts": {
-		"install": "make clean native"
+		"install": "make clean native || gmake clean native"
 	},
 	"man": "./man/fibers.1",
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/laverdet/node-fibers.git"
 	},
-	"os": ["darwin", "linux"],
+	"os": ["darwin", "linux", "sunos", "openbsd", "freebsd"],
 	"engines": {
 		"node": ">=0.5.2"
 	}

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,9 @@ endif
 ifeq ($(NODE_PLATFORM), openbsd)
 	CPP_NODEFLAGS = -fPIC -shared -Wl,-Bdynamic
 endif
+ifeq ($(NODE_PLATFORM), freebsd)
+	CPP_NODEFLAGS = -fPIC -shared -Wl,-Bdynamic
+endif
 
 all: fibers.node
 

--- a/src/platform.mk
+++ b/src/platform.mk
@@ -45,3 +45,6 @@ endif
 ifeq ($(NODE_PLATFORM), openbsd)
 	CPPFLAGS += -DCORO_ASM
 endif
+ifeq ($(NODE_PLATFORM), freebsd)
+	CPPFLAGS += -DCORO_UCONTEXT
+endif


### PR DESCRIPTION
1. Now npm install can successfully install this package with gmake on BSD
2. Build options for FreeBSD added

With this patch it was compiled on my freebsd 6, all tests passed. I hope it'll work on newer versions too. :)

PS: By the way, --march=native doesnt work for gcc prior to 4.2. Well... i think nobody cares about it. ;)
