### PR TITLE
npm includes node-gyp, no need to explicly mention it as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,5 @@
 	},
 	"engines": {
 		"node": ">=0.5.2"
-	},
-	"dependencies": {"node-gyp": "*"}
+	}
 }


### PR DESCRIPTION
npm includes node-gyp, thus there is no need to explicly mention it as dependency
