### PR TITLE
Extend Function.prototype for Fibers

### DIFF
--- a/fibers.js
+++ b/fibers.js
@@ -16,3 +16,32 @@ try {
 // Injects `Fiber` and `yield` in to global scope (for now)
 require(modPath);
 module.exports = Fiber;
+
+// Function.prototype.toSync - Wrap function as Sync
+Object.defineProperty(Function.prototype,"toSync", {
+	enumerable: false, configurable: false, 
+	get: function() { 
+		return (function(context){ 
+			return (function(/*...*/) { 
+				var a = []; for(var i in arguments) { a.push(arguments[i]); }
+				return (require("fibers/future").wrap(context)).apply(context,a).wait(); 
+			});
+		})(this); },
+	set: function() { }
+
+});
+
+// Function.prototype.toSync toString lock
+Object.defineProperty(Function.prototype.toSync,"toString", {
+	enumerable: false, configurable: false, get: function() { return function() {} }, set: function() { }
+});
+
+// Function.prototype.toFiber - Run function as Fiber
+Object.defineProperty(Function.prototype,"asFiber", {
+	enumerable: false, configurable: false, get: function() { return require("fibers")(this).run(); }, set: function() { }
+});
+
+// Function.prototype.toFiber toString lock
+Object.defineProperty(Function.prototype.asFiber,"toString", {
+	enumerable: false, configurable: false, get: function() { return function() {} }, set: function() { }
+});


### PR DESCRIPTION
Allow to use Fibers in context...

Example

``` javascript
(function() {
 console.log( (require("fs").readdir.toSync)(".") );
}).asFiber;
```

<b>asFiber</b> extension

before

``` javascript
(require("fibers")(function() { /* function code */ })).run()
```

after

``` javascript
(function() { /* function code */ }).asFiber
```

<b>toSync</b> extension

before

``` javascript
(require("fibers/future").wrap(asyncFunction))(asyncArguments).wait()
```

after

``` javascript
(asyncFunction.toSync)(asyncArguments)
```
