### PR TITLE
Copy error fields as well

### DIFF
--- a/future.js
+++ b/future.js
@@ -124,6 +124,9 @@ Future.prototype = {
 			var stack = {}, error = this.error instanceof Object ? this.error : new Error(this.error);
 			var longError = Object.create(error);
 			Error.captureStackTrace(stack, Future.prototype.get);
+			for (var f in error) {
+				longError[f] = error[f];
+			}
 			Object.defineProperty(longError, 'stack', {
 				get: function() {
 					var baseStack = error.stack;


### PR DESCRIPTION
Long error construction does not copy all fields. This means data is lost. More information meteor/meteor#1482.
