### PR TITLE
src: fix build error with node.js v0.11.12-pre

### DIFF
--- a/src/fibers.cc
+++ b/src/fibers.cc
@@ -28,7 +28,7 @@ namespace uni {
 	typedef PropertyCallbackInfo<Value> GetterCallbackInfo;
 	typedef PropertyCallbackInfo<void> SetterCallbackInfo;
 	typedef void FunctionType;
-	typedef FunctionCallbackInfo<v8::Value> Arguments;
+	typedef v8::FunctionCallbackInfo<v8::Value> Arguments;
 
 	class HandleScope {
 		v8::HandleScope scope;


### PR DESCRIPTION
Qualify the FunctionCallbackInfo type with its namespace in src/fibers.cc.
Fixes the following compilation error:

```
../src/fibers.cc:32:10: error: reference to 'FunctionCallbackInfo'
is ambiguous
```
