### PR TITLE
intrinsic fixed

### DIFF
--- a/src/coroutine.cc
+++ b/src/coroutine.cc
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #else
 #include <windows.h>
+#include <intrin.h>
 // Stub pthreads into Windows approximations
 #define pthread_t HANDLE
 #define pthread_create(thread, attr, fn, arg) !((*thread)=CreateThread(NULL, 0, &(fn), arg, 0, NULL))


### PR DESCRIPTION
Fixed error like this:
..\src\coroutine.cc(93): error C3861: '_AddressOfReturnAddress': identifier not found