### PR TITLE
fixed nasty bug (crash or memory leak)

### DIFF
--- a/src/fibers.cc
+++ b/src/fibers.cc
@@ -231,7 +231,6 @@ class Fiber {
 				return;
 			}
 
-			that.handle.Dispose();
 			delete &that;
 		}
 


### PR DESCRIPTION
@laverdet 
I found it while investigating a memory leak in streamline's fibers mode. I could get rid of the leak by tweaking the JS code (see https://github.com/Sage/streamlinejs/issues/237) but then I tried to reproduce it with a smaller program and I hit various crashes. 

My repro program is here: https://gist.github.com/bjouhier/0ddde2c67d847de276ee

The fix is very easy: just eliminate a redundant `dispose()` call. With this simple fix, the repro program runs without hiccups and does not leak memory either.
