### PR TITLE
Add flags for POWER and Z architectures

### DIFF
--- a/build.js
+++ b/build.js
@@ -20,7 +20,7 @@ var args = process.argv.slice(2).filter(function(arg) {
 	}
 	return true;
 });
-if (!{ia32: true, x64: true, arm: true}.hasOwnProperty(arch)) {
+if (!{ia32: true, x64: true, arm: true, ppc: true, ppc64: true, s390: true, s390: true}.hasOwnProperty(arch)) {
 	console.error('Unsupported (?) architecture: `'+ arch+ '`');
 	process.exit(1);
 }

--- a/build.js
+++ b/build.js
@@ -20,7 +20,7 @@ var args = process.argv.slice(2).filter(function(arg) {
 	}
 	return true;
 });
-if (!{ia32: true, x64: true, arm: true, ppc: true, ppc64: true, s390: true, s390: true}.hasOwnProperty(arch)) {
+if (!{ia32: true, x64: true, arm: true, ppc: true, ppc64: true, s390: true, s390x: true}.hasOwnProperty(arch)) {
 	console.error('Unsupported (?) architecture: `'+ arch+ '`');
 	process.exit(1);
 }


### PR DESCRIPTION
The current code does not compile on POWER and Z Linux platforms. It fails with "Unsupported architecture" error.  This is raised in issue 90: https://github.com/laverdet/node-fibers/issues/190

This required adding the arch flags: ppc, ppc64, s390 and s390x. Please review the changes and approve.