### PR TITLE
src: disable SetResourceConstraints with new v8

### DIFF
--- a/src/fibers.cc
+++ b/src/fibers.cc
@@ -137,7 +137,11 @@ namespace uni {
 	}
 
 	void SetResourceConstraints(Isolate* isolate, ResourceConstraints* constraints) {
+		// Newer V8 versions require that resource constraints
+		// are specified upfront, when the isolate is created.
+#if NODE_MODULE_VERSION == 0x000D
 		v8::SetResourceConstraints(isolate, constraints);
+#endif
 	}
 
 #else


### PR DESCRIPTION
Newer V8 versions require that resource constraints are specified
upfront, when the isolate is created.  That means node-fibers is
not in a position to change the limits when it's loaded because
the isolate has already been created at that point.

The sad downside of course is that fiber stacks are now much larger
than they otherwise would be.  At least it compiles with io.js now.

Fixes #203.