### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"type": "git",
 		"url": "git://github.com/laverdet/node-fibers.git"
 	},
+	"license": "MIT",
 	"engines": {
 		"node": ">=0.5.2"
 	}


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/