### PR TITLE
iojs 2.1 compatibility: remove extra args to Signature::New().

### DIFF
--- a/src/fibers.cc
+++ b/src/fibers.cc
@@ -126,11 +126,9 @@ namespace uni {
 
 	Handle<Signature> NewSignature(
 		Isolate* isolate,
-		Handle<FunctionTemplate> receiver = Handle<FunctionTemplate>(),
-		int argc = 0,
-		Handle<FunctionTemplate> argv[] = 0
+		Handle<FunctionTemplate> receiver = Handle<FunctionTemplate>()
 	) {
-		return Signature::New(isolate, receiver, argc, argv);
+		return Signature::New(isolate, receiver);
 	}
 
 	void AdjustAmountOfExternalAllocatedMemory(Isolate* isolate, int64_t change_in_bytes) {


### PR DESCRIPTION
I don't know when these arguments became optional and then illegal,
but iojs 2.1 (V8 4.2) does not like seeing them at all, and nodejs
0.12.0 (V8 3.28) is fine without seeing them.

I didn't test nodejs 0.11.x (x >= 13) which also follow this path
and might not like it.

The module compiles, and tests pass, with nodejs 0.12.0 and iojs
2.1.0.