### PR TITLE
Fixes problem with Jest require

### DIFF
--- a/fibers.js
+++ b/fibers.js
@@ -8,12 +8,12 @@ Math.random();
 
 // Look for binary for this platform
 var v8 = 'v8-'+ /[0-9]+\.[0-9]+/.exec(process.versions.v8)[0];
-var modPath = path.join(__dirname, 'bin', process.platform+ '-'+ process.arch+ '-'+ v8, 'fibers');
+var modPath = path.join(__dirname, 'bin', process.platform+ '-'+ process.arch+ '-'+ v8, 'fibers.node');
 try {
-	fs.statSync(modPath+ '.node');
+	fs.statSync(modPath);
 } catch (ex) {
 	// No binary!
-	throw new Error('`'+ modPath+ '.node` is missing. Try reinstalling `node-fibers`?');
+	throw new Error('`'+ modPath+ '` is missing. Try reinstalling `node-fibers`?');
 }
 
 // Pull in fibers implementation


### PR DESCRIPTION
Adds the .node file extension to the require statement.
With this fix Jest works with projects that use fibers.
The issue: https://github.com/facebook/jest/issues/353

This issue blocks our package progress because our tests fail partially since we have added fibers as dependency and Jest cannot load the fibers module. So it would be great if you could merge this, even though technically the issue is somewhere in the Jest module loader. However I couldn't figure out how to fix it in Jest. Thanks.