### PR TITLE
binding: Use `ASM` mode on the linux + non glibc environ

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,7 +38,21 @@
 						'ldflags': ['-pthread'],
 					}
 				],
-				['OS == "linux" or OS == "solaris" or OS == "sunos" or OS == "freebsd" or OS == "aix"', {'defines': ['CORO_UCONTEXT']}],
+				['OS == "linux"',
+					{
+						'variables': {
+							'USE_GLIBC': '<!(ldd --version 2>&1 | head -n 1 | grep -i "glibc" | wc -l)',
+						},
+						'conditions': [
+							['<(USE_GLIBC) == 1',
+								{'defines': ['CORO_UCONTEXT'],},
+								# no use glibc
+								{'defines': ['CORO_ASM'],}
+							],
+						],
+					},
+				],
+				['OS == "solaris" or OS == "sunos" or OS == "freebsd" or OS == "aix"', {'defines': ['CORO_UCONTEXT']}],
 				['OS == "mac"', {'defines': ['CORO_SJLJ']}],
 				['OS == "openbsd"', {'defines': ['CORO_ASM']}],
 				['target_arch == "arm"',


### PR DESCRIPTION
POSIX no more support `ucontext_t` operation.

```
Error: Error relocating /node-fibers/bin/linux-x64-v8-4.6/fibers.node: swapcontext: symbol not found
    at Error (native)
    at Object.Module._extensions..node (module.js:440:18)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (/node-fibers/fibers.js:20:37)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
```

Reference:
http://wiki.musl-libc.org/wiki/Open_Issues#ucontext.h

This PR solve can't use problem of the alpine linux (test alpine-node docker image) 