### PR TITLE
Enable the libcoro asm backend on macos

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -52,7 +52,7 @@
 					},
 				],
 				['OS == "solaris" or OS == "sunos" or OS == "freebsd" or OS == "aix"', {'defines': ['CORO_UCONTEXT']}],
-				['OS == "mac"', {'defines': ['CORO_SJLJ']}],
+				['OS == "mac"', {'defines': ['CORO_ASM']}],
 				['OS == "openbsd"', {'defines': ['CORO_ASM']}],
 				['target_arch == "arm" or target_arch == "arm64"',
 					{

--- a/src/libcoro/coro.c
+++ b/src/libcoro/coro.c
@@ -123,7 +123,7 @@ trampoline (int sig)
 
   asm (
        "\t.text\n"
-       #if _WIN32 || __CYGWIN__
+       #if _WIN32 || __CYGWIN__ || __APPLE__
        "\t.globl _coro_transfer\n"
        "_coro_transfer:\n"
        #else

--- a/src/libcoro/coro.h
+++ b/src/libcoro/coro.h
@@ -305,6 +305,8 @@ void coro_stack_free (struct coro_stack *stack);
 #  define CORO_LOSER 1 /* you don't win with windoze */
 # elif __linux && (__i386 || (__x86_64 && !__ILP32))
 #  define CORO_ASM 1
+# elif __APPLE__ && (__i386 || (__x86_64 && !__ILP32))
+#  define CORO_ASM 1
 # elif defined HAVE_UCONTEXT_H
 #  define CORO_UCONTEXT 1
 # elif defined HAVE_SETJMP_H && defined HAVE_SIGALTSTACK


### PR DESCRIPTION
According to my tests, the only reason the asm backend doesn't work on macos is because an underscore is needed in front of the name. So I added that in. This makes fiber creation much faster, since it no longer requires sending and then receiving a signal.