### PR TITLE
Fix tests in v9 and v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: node_js
 node_js:
   - "6"
   - "8"
+  - "10"
 
 cache:
   directories:

--- a/test.js
+++ b/test.js
@@ -11,7 +11,9 @@ function runTest(test, cb) {
 	}
 	env.NODE_PATH = __dirname;
 	var args = [];
-	if (process.versions.modules >= 57) {
+	if (process.versions.modules >= 57 && process.versions.modules < 59) {
+		// Node v8 requires forcing async hook checks. In Node v9 (>=59) and beyond,
+		// async hooks checks are on by default (and the param no longer exists).
 		args.push('--force-async-hooks-checks');
 	}
 	args.push(path.join('test', test));

--- a/test/async-hooks.js
+++ b/test/async-hooks.js
@@ -13,9 +13,15 @@ class TestResource extends AsyncResource {
 	}
 
 	run(cb) {
-		this.emitBefore();
-		cb();
-		this.emitAfter();
+		// In the v8 API, only emitBefore() and emitAfter() are available
+		if (process.versions.modules < 59) {
+			this.emitBefore();
+			cb();
+			this.emitAfter();
+		} else {
+			// In v9 and higher, emitBefore() and emitAfter() are deperecated in favor of runInAsyncScope().
+			this.runInAsyncScope(cb);
+		}
 	}
 }
 


### PR DESCRIPTION
In node v9, the async-hooks API changed in the following ways, causing tests to break:

- force-async-hooks-checks became on by default. This made the parameter "--force-async-hooks-checks" invalid and unnecessary
- emitBefore() and emitAfter() were deprecated. This was replaced with runInAsyncScope().

This PR addresses the necessary API changes so that the tests run properly in node 9 and 10. In addition, v10 testing is turned on in Travis-CI.