### PR TITLE
Bundle binary for Alpine Linux/musl distributions

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 var cp = require('child_process'),
 	fs = require('fs'),
-	path = require('path');
+	path = require('path'),
+	detectLibc = require('detect-libc');
 
 // Parse args
 var force = false, debug = false;
@@ -26,13 +27,9 @@ if (!{ia32: true, x64: true, arm: true, arm64: true, ppc: true, ppc64: true, s39
 	console.error('Unsupported (?) architecture: `'+ arch+ '`');
 	process.exit(1);
 }
-if (platform === 'linux') {
-	// See USE_MUSL in binding.gyp
-	var libCFamily = parseInt(cp.execSync('ldd --version 2>&1 | head -n1 | grep "musl" | wc -l')) ? 'musl' : 'glibc';
-}
 
 // Test for pre-built library
-var modPath = platform+ '-'+ arch+ '-'+ process.versions.modules+ ((platform === 'linux') ? '-'+ libCFamily : '');
+var modPath = platform+ '-'+ arch+ '-'+ process.versions.modules+ ((platform === 'linux') ? '-'+ detectLibc.family : '');
 if (!force) {
 	try {
 		fs.statSync(path.join(__dirname, 'bin', modPath, 'fibers.node'));

--- a/build.js
+++ b/build.js
@@ -26,9 +26,13 @@ if (!{ia32: true, x64: true, arm: true, arm64: true, ppc: true, ppc64: true, s39
 	console.error('Unsupported (?) architecture: `'+ arch+ '`');
 	process.exit(1);
 }
+if (platform === 'linux') {
+	// See USE_MUSL in binding.gyp
+	var libCFamily = parseInt(cp.execSync('ldd --version 2>&1 | head -n1 | grep "musl" | wc -l')) ? 'musl' : 'glibc';
+}
 
 // Test for pre-built library
-var modPath = platform+ '-'+ arch+ '-'+ process.versions.modules;
+var modPath = platform+ '-'+ arch+ '-'+ process.versions.modules+ ((platform === 'linux') ? '-'+ libCFamily : '');
 if (!force) {
 	try {
 		fs.statSync(path.join(__dirname, 'bin', modPath, 'fibers.node'));

--- a/fibers.js
+++ b/fibers.js
@@ -1,13 +1,14 @@
 if (process.fiberLib) {
 	module.exports = process.fiberLib;
 } else {
-	var fs = require('fs'), path = require('path');
+	var fs = require('fs'), path = require('path'), detectLibc = require('detect-libc');
 
 	// Seed random numbers [gh-82]
 	Math.random();
 
 	// Look for binary for this platform
-	var modPath = path.join(__dirname, 'bin', process.platform+ '-'+ process.arch+ '-'+ process.versions.modules, 'fibers');
+	var modPath = path.join(__dirname, 'bin', process.platform+ '-'+ process.arch+ '-'+ process.versions.modules+
+		((process.platform === 'linux') ? '-'+ detectLibc.family : ''), 'fibers');
 	try {
 		// Pull in fibers implementation
 		process.fiberLib = module.exports = require(modPath).Fiber;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+	"name": "fibers",
+	"version": "3.1.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
 	"license": "MIT",
 	"engines": {
 		"node": ">=8.0.0"
+	},
+	"dependencies": {
+		"detect-libc": "^1.0.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fibers",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"description": "Cooperative multi-tasking for Javascript",
 	"keywords": [
 		"fiber", "fibers", "coroutine", "thread", "async", "parallel", "worker", "future", "promise"],
@@ -17,6 +17,6 @@
 	},
 	"license": "MIT",
 	"engines": {
-		"node": ">=0.5.2"
+		"node": ">=8.0.0"
 	}
 }


### PR DESCRIPTION
I’m working on a [Docker image for running Meteor apps in Node Alpine](https://github.com/disney/meteor-base/). I was discussing ways to improve it with @benjamn, and he suggested that it could be streamlined if the Alpine binary for Fibers was included in its NPM distribution, the way Fibers includes binaries for some other platforms:

```sh
$ docker run node:alpine npm install fibers

> fibers@3.0.0 install /node_modules/fibers
> node build.js || nodejs build.js

`linux-x64-64` exists; testing
Problem with the binary; manual build incoming
gyp ERR! configure error
gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
```

This PR changes the paths for the built Linux binaries to include `-glibc` or `-musl` in the folder name, e.g. `bin/linux-x64-64-musl/fibers.node`. It also updates references to pull the correct file. This will allow you to build both a glibc and a musl binary, so that Alpine and other musl-using distros have a prebuilt binary (while preserving the glibc binary for currently supported platforms).

I don’t see how you build all the binaries before publishing, but I presume it’s a manual process involving firing up every supported environment? I can supply instructions for Alpine, to build the musl binary, assuming you have Docker installed and are at the root of this repo:

```sh
docker run -itv $(pwd):/node-fibers node:alpine sh
apk add python make g++
cd /node-fibers
npm install --global node-gyp
node build -f
```

You should see output ending in ``Installed in `/node-fibers/bin/linux-x64-64-musl/fibers.node` ``.