### PR TITLE
Support Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"license": "MIT",
 	"engines": {
-		"node": ">=8.0.0"
+		"node": ">=6.0.0"
 	},
 	"dependencies": {
 		"detect-libc": "^1.0.3"


### PR DESCRIPTION
The Travis tests run on Node 6, so the module should support node 6 as well.