### PR TITLE
Use MAP_STACK on OpenBSD.

### DIFF
--- a/src/libcoro/coro.c
+++ b/src/libcoro/coro.c
@@ -650,7 +650,11 @@ coro_stack_alloc (struct coro_stack *stack, unsigned int size)
 
   #if CORO_MMAP
     /* mmap supposedly does allocate-on-write for us */
+#ifdef __OpenBSD__
+    base = mmap (0, ssze, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+#else
     base = mmap (0, ssze, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+#endif
 
     if (base == (void *)-1)
       {


### PR DESCRIPTION
On OpenBSD, if `mmap` memory to be used as a stack, you must include `MAP_STACK` or the kernel will kill your app:

```
syscall [node]85688/482963 sp be998db8e28 not inside 7f7fffbc9000-7f7ffffc8000
syscall [node]61911/166063 sp e233b020e28 not inside 7f7fffbc6000-7f7ffffc5000
syscall [node]57856/111589 sp e942c971e28 not inside 7f7fffbfb000-7f7fffffb000
syscall [node]87861/132301 sp 3fff6186e28 not inside 7f7fffbc5000-7f7ffffc4000
syscall [node]25813/452206 sp d9d974c3e28 not inside 7f7fffbe0000-7f7ffffe0000
syscall [node]39489/481737 sp 6157078ae28 not inside 7f7fffbec000-7f7ffffec000 
syscall [node]64230/59954 sp 7c94b4b9e28 not inside 7f7fffbec000-7f7ffffec000
syscall [node]14172/343815 sp 5b0eda2be28 not inside 7f7fffbd4000-7f7ffffd4000 
``` 

This PR makes all the tests pass on OpenBSD (and they still pass on Linux - thanks to @MagisterQuis for testing!).

More info oh `MAP_STACK` here: http://openbsd-archive.7691.n7.nabble.com/stack-register-checking-td338238.html