### PR TITLE
improvement(build.js): add install message for Arch linux users

### DIFF
--- a/build.js
+++ b/build.js
@@ -73,7 +73,8 @@ function build() {
 				'Windows + OS X instructions here: https://github.com/nodejs/node-gyp\n'+
 				'Ubuntu users please run: `sudo apt-get install g++ build-essential`\n'+
 				'RHEL users please run: `yum install gcc-c++` and `yum groupinstall \'Development Tools\'` \n'+
-				'Alpine users please run: `sudo apk add python make g++`'
+				'Alpine users please run: `sudo apk add python make g++` \n'+
+				'Arch users please run: `sudo pacman -S base-devel'
 			);
 			return process.exit(err);
 		}


### PR DESCRIPTION
I would like to add a helper message for Arch and Manjaro linux when build errors like so:

```js
console.error(
  'node-gyp exited with code: '+ err+ '\n'+
  'Please make sure you are using a supported platform and node version. If you\n'+
  'would like to compile fibers on this machine please make sure you have setup your\n'+
  'build environment--\n'+
  'Windows + OS X instructions here: https://github.com/nodejs/node-gyp\n'+
  'Ubuntu users please run: `sudo apt-get install g++ build-essential`\n'+
  'RHEL users please run: `yum install gcc-c++` and `yum groupinstall \'Development Tools\'` \n'+
  'Alpine users please run: `sudo apk add python make g++`'
);
```
