### PR TITLE
Mac M1 - darwin arm64 support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -55,11 +55,18 @@
 				['OS == "solaris" or OS == "sunos" or OS == "freebsd" or OS == "aix"', {'defines': ['CORO_UCONTEXT']}],
 				['OS == "mac"', {'defines': ['CORO_ASM']}],
 				['OS == "openbsd"', {'defines': ['CORO_ASM']}],
-				['target_arch == "arm" or target_arch == "arm64"',
+				['target_arch == "arm"',
 					{
 						# There's been problems getting real fibers working on arm
 						'defines': ['CORO_PTHREAD'],
 						'defines!': ['CORO_UCONTEXT', 'CORO_SJLJ', 'CORO_ASM'],
+					},
+				],
+				['target_arch == "arm64"',
+					{
+						# There's been problems getting real fibers working on arm
+						'defines': ['CORO_UCONTEXT', '_XOPEN_SOURCE'],
+						'defines!': ['CORO_PTHREAD', 'CORO_SJLJ', 'CORO_ASM'],
 					},
 				],
 			],


### PR DESCRIPTION
Hello!

I'm from Meteor and we have been trying to use Fibers with Mac M1 lately, but the CORO_PTHREAD implementation is producing deadlocks in some of our flows, like spawning any process inside a fiber. You can see more details in my answer here: https://github.com/meteor/meteor/discussions/11633#discussioncomment-1599596

In summary, seems like a pthread condition variable is being used even after the coroutine is deallocated. I haven't followed the analysis to a fix yet.

After some struggle with CORO_PTHREAD, I've changed the arm64 selector to use CORO_UCONTEXT passing the -D_XOPEN_SOURCE option which enables the usage of legacy ucontext library on mac.

It is working and in our analysis, it's pretty faster too!

I'm opening this PR in case you want to merge and release, which in this case we can also go back from our fork!

Thanks for your good work.