### PR TITLE
Restore an *actual* async resource, not just the ID

### DIFF
--- a/fibers.js
+++ b/fibers.js
@@ -30,6 +30,7 @@ function setupAsyncHacks(Fiber) {
 	// Older (or newer?) versions of node may not support this API
 	try {
 		var aw = process.binding('async_wrap');
+    var ah = require('async_hooks');
 		var getAsyncIdStackSize;
 
 		if (aw.asyncIdStackSize instanceof Function) {
@@ -71,6 +72,7 @@ function setupAsyncHacks(Fiber) {
 			for (; ii > 0; --ii) {
 				var asyncId = asyncIds[kExecutionAsyncId];
 				stack[ii - 1] = {
+          asyncResource: ah.executionAsyncResource(),
 					asyncId: asyncId,
 					triggerId: asyncIds[kTriggerAsyncId],
 				};
@@ -82,6 +84,7 @@ function setupAsyncHacks(Fiber) {
 		function restoreStack(stack) {
 			for (var ii = 0; ii < stack.length; ++ii) {
 				pushAsyncContext(stack[ii].asyncId, stack[ii].triggerId);
+				aw.execution_async_resources.push(stack[ii].asyncResource);
 			}
 		}
 

--- a/test/async-hooks.js
+++ b/test/async-hooks.js
@@ -4,7 +4,7 @@ if (process.versions.modules < 57) {
 	console.log('pass');
 	return;
 }
-const { AsyncResource } = require('async_hooks');
+const { AsyncResource, executionAsyncResource } = require('async_hooks');
 const Fiber = require('fibers');
 
 class TestResource extends AsyncResource {
@@ -28,7 +28,12 @@ class TestResource extends AsyncResource {
 let tmp = Fiber(function() {
 	let resource = new TestResource;
 	resource.run(function() {
+		let asyncResource = executionAsyncResource();
 		Fiber.yield();
+		if (executionAsyncResource() !== asyncResource) {
+			console.log('fail');
+			throw new Error('executionAsyncResource not restored correctly');
+		}
 	});
 });
 tmp.run();


### PR DESCRIPTION
I know the project is dying, feel free to ignore this PR (I need it for my work on `AsyncResources` and it seems generally relevant)

The existing save/restore stack looses the reference to the *actual* `AsyncResource` - if you try to use (for example) `AsyncLocalStorage` - it will fail because the current asyncResource is undefined (even though the ID *is*).

This PR adds one more gnarly hack to these functions - to grab the existing `AsyncResource` then manually push it back onto the stack.

I modified the async_hooks test to check for this too. All the tests that were passing before are passing now (for some reason pool and cleanup fail for me on master).